### PR TITLE
[ATK-236] Cost center handling added to reference implementation and documentation

### DIFF
--- a/python-client/README.md
+++ b/python-client/README.md
@@ -229,9 +229,9 @@ objects. Each object must be of following structure:
 {
     "externalId": "<any string>",
     "names": {
-        "en": "<human readable department name in English>",
-        "fi": "<human readable department name in Finnish>",
-        "sv": "<human readable department name in Swedish>"
+        "en": "<human readable cost center name in English>",
+        "fi": "<human readable cost center name in Finnish>",
+        "sv": "<human readable cost center name in Swedish>"
     }
 }
 ```

--- a/python-client/README.md
+++ b/python-client/README.md
@@ -64,6 +64,9 @@ Following command line options are available:
 `-sd / --suppress_deps` Departments are ignored: they are neither read from the source nor
 sent to the API
 
+`-sc / --suppress_ccs` Cost centers are ignored: they are neither read from the source nor
+sent to the API
+
 `-se / --suppress_employees` Employee data is ignored: it is neither read from the source nor
 sent to the API
 
@@ -77,8 +80,8 @@ source, but it is not sent to the API
 
 `python sync_data.py --read_only --suppress_employees --suppress_absences`
 
-Only retrieves department information and prints it out on the screen. Printout will be something
-along the lines of:
+Only retrieves department and cost center information and prints it out on the screen. Printout
+will be something along the lines of:
 
 ```
 [
@@ -98,9 +101,26 @@ along the lines of:
     },
     ...
 ]
+[
+    {
+        "externalId": "cc1234",
+        "names": {
+            "en": "General Administration",
+            "fi": "Yleishallinto"
+        }
+    },
+    {
+        "externalId": "cc2345",
+        "names": {
+            "en": "Salaried employees",
+            "fi": "Tuntipalkkaiset työntekijät"
+        }
+    },
+    ...
+]
 ```
 
-`python sync_data.py --read_only -sd -sa`
+`python sync_data.py --read_only -sd -sc -sa`
 
 Only retrieves and prints out the employee data without invoking the API. This kind of information may
 be shown on the console:
@@ -199,6 +219,25 @@ objects. Each object must be of following structure:
 
 Not all languages are required, but of course it helps to have at least one human readable name.
 External ID should be permanent, so any changes to the department names can be handled correctly.
+
+`get_cost_centers()`
+
+Retrieves the cost center data from HRM or other source as an array whose items are dictionary
+objects. Each object must be of following structure:
+
+```
+{
+    "externalId": "<any string>",
+    "names": {
+        "en": "<human readable department name in English>",
+        "fi": "<human readable department name in Finnish>",
+        "sv": "<human readable department name in Swedish>"
+    }
+}
+```
+
+Not all languages are required, but of course it helps to have at least one human readable name.
+External ID should be permanent, so any changes to the cost center names can be handled correctly.
 
 `get_personnel()`
 

--- a/python-client/aavahr_graphql.py
+++ b/python-client/aavahr_graphql.py
@@ -167,16 +167,19 @@ def get_statuses(parameters: dict, message_ids: list) -> dict:
     """
 
     query = gql('''
-        query processingStatus(
+        query processingStatusWithVerify(
             $messageIds: [ID!]!
+            $organizationExternalId: ID!
         ) {
-            processingStatus(
-                messageIds: $messageIds
+            processingStatusWithVerify(
+                messageIds: $messageIds,
+                organizationExternalId: $organizationExternalId
             ) {
                 messageId,
                 importType,
                 importStatus,
-                timestamp
+                timestamp,
+                error
             }
         }
     ''')
@@ -187,6 +190,7 @@ def get_statuses(parameters: dict, message_ids: list) -> dict:
 
     variables = {
         "messageIds": message_ids,
+        "organizationExternalId": parameters['organizationId']
     }
 
     result = client.execute(query, variable_values=json.dumps(variables))

--- a/python-client/aavahr_graphql.py
+++ b/python-client/aavahr_graphql.py
@@ -46,11 +46,11 @@ def import_departments(parameters: dict, departments: dict) -> dict:
 
     mutation = '''
         mutation importDepartments(
-            $organizationId: ID!
+            $organizationExternalId: ID!
             $departments: [DepartmentInput!]!
         ) {
             importDepartments(
-            organizationExternalId: $organizationId
+            organizationExternalId: $organizationExternalId
             departments: $departments
             ) {
             messageId
@@ -64,7 +64,7 @@ def import_departments(parameters: dict, departments: dict) -> dict:
 
     query = gql(mutation)
     variables = {
-        "organizationId": parameters['organizationId'],
+        "organizationExternalId": parameters['organizationId'],
         "departments": departments,
     }
 
@@ -86,11 +86,11 @@ def import_cost_centers(parameters: dict, costCenters: dict) -> dict:
 
     mutation = '''
         mutation importCostCenters(
-            $organizationId: ID!
+            $organizationExternalId: ID!
             $costCenters: [CostCenterInput!]!
         ) {
             importCostCenters(
-            organizationExternalId: $organizationId
+            organizationExternalId: $organizationExternalId
             costCenters: $costCenters
             ) {
             messageId
@@ -104,7 +104,7 @@ def import_cost_centers(parameters: dict, costCenters: dict) -> dict:
 
     query = gql(mutation)
     variables = {
-        "organizationId": parameters['organizationId'],
+        "organizationExternalId": parameters['organizationId'],
         "costCenters": costCenters,
     }
 
@@ -126,11 +126,11 @@ def import_employees(parameters: dict, employees: dict) -> dict:
 
     mutation = '''
         mutation importEmployees(
-            $organizationId: ID!
+            $organizationExternalId: ID!
             $employees: [EmployeeInput!]!
         ) {
             importEmployees(
-                organizationExternalId: $organizationId
+                organizationExternalId: $organizationExternalId
                 employees: $employees
             ) {
             messageId
@@ -144,7 +144,7 @@ def import_employees(parameters: dict, employees: dict) -> dict:
 
     query = gql(mutation)
     variables = {
-        "organizationId": parameters['organizationId'],
+        "organizationExternalId": parameters['organizationId'],
         "employees": employees,
     }
 
@@ -166,11 +166,11 @@ def import_absences(parameters: dict, absences) -> dict:
 
     mutation = '''
         mutation importAbsences(
-            $organizationId: ID!
+            $organizationExternalId: ID!
             $absences: [AbsenceInput!]!
         ) {
             importAbsences(
-                organizationExternalId: $organizationId
+                organizationExternalId: $organizationExternalId
                 absences: $absences
             ) {
                 messageId
@@ -184,7 +184,7 @@ def import_absences(parameters: dict, absences) -> dict:
 
     query = gql(mutation)
     variables = {
-        "organizationId": parameters['organizationId'],
+        "organizationExternalId": parameters['organizationId'],
         "absences": absences,
     }
 

--- a/python-client/aavahr_graphql.py
+++ b/python-client/aavahr_graphql.py
@@ -72,6 +72,46 @@ def import_departments(parameters: dict, departments: dict) -> dict:
     return result
 
 
+def import_cost_centers(parameters: dict, costCenters: dict) -> dict:
+    """
+    Imports the cost center information to Aava API.
+
+    Args:
+        parameters (dict): Parameters for connecting to Aava API (see properties-template.json)
+        costCenters (dict): A dictionary object containing the cost center data (similar to department data)
+
+    Returns:
+        dict: Structure containing the request ID for querying the status of request; in r['importCostCenters']['messageId']
+    """
+
+    mutation = '''
+        mutation importCostCenters(
+            $organizationId: ID!
+            $costCenters: [CostCenterInput!]!
+        ) {
+            importCostCenters(
+            organizationExternalId: $organizationId
+            costCenters: $costCenters
+            ) {
+            messageId
+            }
+        }
+    '''
+    client = Client(transport=RequestsHTTPTransport(
+        url=parameters['aavaApiServer'] + '/hr',
+        headers={'Authorization': 'Bearer ' + parameters['bearerToken']})
+    )
+
+    query = gql(mutation)
+    variables = {
+        "organizationId": parameters['organizationId'],
+        "costCenters": costCenters,
+    }
+
+    result = client.execute(query, variable_values=json.dumps(variables))
+    return result
+
+
 def import_employees(parameters: dict, employees: dict) -> dict:
     """
     Imports the employee information retrieved from HRM to Aava API

--- a/python-client/aavahr_graphql.py
+++ b/python-client/aavahr_graphql.py
@@ -203,7 +203,7 @@ def get_statuses(parameters: dict, message_ids: list) -> dict:
         message_ids (list): An array containing the message IDs received from import requests
 
     Returns:
-        dict: A dictionary object with key 'processingStatus', under which there is an array of status objects
+        dict: A dictionary object with key 'processingStatusWithVerify', under which there is an array of status objects
     """
 
     query = gql('''

--- a/python-client/examples/excel_example_hrm.py
+++ b/python-client/examples/excel_example_hrm.py
@@ -34,6 +34,12 @@ def get_departments():
     return departments
 
 
+def get_get_cost_centers():
+    # this function intentionally returns nothing, structurally it
+    # can resemble 'get_departments'
+    return []
+
+
 def get_personnel():
     # Load properties and check that they are structurally OK
     props = utils.load_properties()

--- a/python-client/examples/simple_example_hrm.py
+++ b/python-client/examples/simple_example_hrm.py
@@ -20,6 +20,10 @@ def get_departments():
     return departments
 
 
+def get_cost_centers():
+    return []
+
+
 def get_personnel():
     employees = [
         {

--- a/python-client/examples/sympahr_example_hrm.py
+++ b/python-client/examples/sympahr_example_hrm.py
@@ -85,15 +85,15 @@ def load_sympa():
         # Add information of past and current departments
         for d in e["Työsuhdetiedot"]:
             try:
-                assert d["Kustannuspaikka"] != None
+                assert d["Osasto"] != None
             except Exception as ex:
                 errors.append(repr(ex))
                 continue
 
-            d_id = get_depId(d["Kustannuspaikka"])
+            d_id = get_depId(d["Osasto"])
 
             # make sure the department info is in the deps array
-            deps[d_id] = d["Kustannuspaikka"]
+            deps[d_id] = d["Osasto"]
 
             d_info = {
                 'externalId': d_id,
@@ -120,6 +120,11 @@ def get_departments():
             'names': {'fi': deps[key]}
         })
     return departments
+
+
+def get_cost_centers():
+    # intentionally returns nothing
+    return []
 
 
 def get_personnel():

--- a/python-client/sync_data.py
+++ b/python-client/sync_data.py
@@ -94,7 +94,7 @@ while True:
     ready = True
     results = api.get_statuses(props, message_ids)
 
-    for r in results['processingStatus']:
+    for r in results['processingStatusWithVerify']:
         if r['importStatus'] == 'UNKNOWN' or r['importStatus'] == 'IN_PROGRESS':
             ready = False
 
@@ -105,7 +105,9 @@ while True:
     sleep(1)
 
 
-for r in results['processingStatus']:
+for r in results['processingStatusWithVerify']:
     print("\nFor " + str(r['importType']) + " at " + str(r['timestamp']))
     print("Message ID: " + r['messageId'])
     print("Status    : " + r['importStatus'])
+    if r['importStatus'] == 'FAILURE':
+        print("Error     : " + r['error'])

--- a/python-client/sync_data.py
+++ b/python-client/sync_data.py
@@ -34,6 +34,20 @@ except Exception as e:
     print("Module loading failed:", repr(e))
     exit()
 
+acceptable_args = [
+    '--help',
+    '-sd', '--suppress_deps',
+    '-se', '--suppress_employees',
+    '-sa', '--suppress_absences',
+    '-sc', '--suppress_ccs',
+    '--read_only'
+]
+
+for a in argv[1:]:
+    if a not in acceptable_args:
+        print('Argument ' + a + ' not recognized, exiting!')
+        exit()
+
 if '--help' in argv:
     print('''
     How to use:
@@ -44,6 +58,7 @@ if '--help' in argv:
     -sd / --suppress_deps - Don't read or write department information
     -se / --suppress_employees - Don't read or write employee information
     -sa / --suppress_absences - Don't read or write absence information
+    -sc / --suppress_ccs - Don't read or write cost center information
     --read_only - Don't make API call, only print out the data that was read from source
     ''')
     exit()
@@ -66,6 +81,16 @@ if '-sd' not in argv and '--suppress_deps' not in argv:
         print("Importing " + str(len(deps)) + " departments...")
         res_deps = api.import_departments(props, deps)
         message_ids.append(res_deps['importDepartments']['messageId'])
+
+if '-sc' not in argv and '--suppress_ccs' not in argv:
+    # Load cost center data from HRM adjacent system and push it to Aava-API
+    ccs = hrm.get_cost_centers()
+    if '--read_only' in argv:
+        print(json.dumps(ccs, indent=4, sort_keys=True))
+    else:
+        print("Importing " + str(len(ccs)) + " cost centers...")
+        res_ccs = api.import_cost_centers(props, ccs)
+        message_ids.append(res_ccs['importCostCenters']['messageId'])
 
 if '-se' not in argv and '--suppress_employees' not in argv:
     # Load employee data from HRM and push it to Aava-API


### PR DESCRIPTION
Kustannuspaikkojen tuontia Aava-APIin jouduttiin muuttamaan, aikaisemman yksinkertaisen vapaatekstikentän sijaan tietorakenne muistuttaakin nyt osastojen muotoa. Tämän hanskaamista varten tein muutokset sekä GraphQL-käsittelyyn että päämoduliin. Dokumentaatio tuli myös päivitettyä.

Aikaisempaa perua (jota ei ollut aiemmin mergetty) oli statuksen hakemiseen käytetyn queryn vaihtaminen processingStatusWithVerifyksi.