### PR TITLE
[ATK-404] Warnings handled when matching employee ID not found for an absentee

### DIFF
--- a/python-client/aavahr_graphql.py
+++ b/python-client/aavahr_graphql.py
@@ -196,7 +196,9 @@ def get_statuses(parameters: dict, message_ids: list) -> dict:
     """
     Used to query the status of import operations. Returns a list of status objects, each object containing
     the request ID ('messageId'), timestamp ('timestamp'), import type ('importType') and the current status
-    of the operation (key 'importStatus', value one of UNKNOWN, IN_PROGRESS, FAILURE, DONE)
+    of the operation (key 'importStatus', value one of UNKNOWN, IN_PROGRESS, FAILURE, DONE). If there is an
+    error, the 'error' parameter contains a string telling about it. Also, if the operation was succesful
+    with some minor hitches, the 'warnings' value gives more information about the problematic inputs.
 
     Args:
         parameters (dict): Parameters for connecting to Aava API (see properties-template.json)

--- a/python-client/aavahr_graphql.py
+++ b/python-client/aavahr_graphql.py
@@ -219,7 +219,8 @@ def get_statuses(parameters: dict, message_ids: list) -> dict:
                 importType,
                 importStatus,
                 timestamp,
-                error
+                error,
+                warnings { warning, externalId }
             }
         }
     ''')

--- a/python-client/sync_data.py
+++ b/python-client/sync_data.py
@@ -136,3 +136,7 @@ for r in results['processingStatusWithVerify']:
     print("Status    : " + r['importStatus'])
     if r['importStatus'] == 'FAILURE':
         print("Error     : " + r['error'])
+    if r['warnings']:
+        print("\nThere were warnings:")
+        for warning in r['warnings']:
+            print(warning['warning'], warning['externalId'])


### PR DESCRIPTION
Hyödynnetään ATK-350:ssä lisättyä toiminnallisuutta, jolla API palauttaa virheilmoituksen sellaisista työntekijöistä, joiden poissaoloa yritettiin syöttää, mutta joita vastaavaa ID:tä ei löydy tietokannasta.